### PR TITLE
add skull stripping and norm rules

### DIFF
--- a/afids-auto-apply/workflow/Snakefile
+++ b/afids-auto-apply/workflow/Snakefile
@@ -7,9 +7,7 @@ import os
 from os.path import join
 import pandas as pd
 
-
 configfile: "config/snakebids.yml"
-
 
 # writes inputs_config.yml and updates config dict
 inputs = snakebids.generate_inputs(
@@ -60,10 +58,36 @@ rule all:
             **inputs["t1w"].input_zip_lists,
         ),
 
-
+rule skull_strip: 
+    input: 
+    	brainskull = inputs["t1w"].input_path,
+    output: 
+        brain= bids(
+                root=join(config["output_dir"], "skull_stripped"),
+                datatype="anat",
+                res="native",
+                suffix="T1w.nii.gz",
+                desc="synthstrip",
+                space=config["space"],
+                **inputs["t1w"].input_wildcards,
+            ),
+        mask=   bids(
+                root=join(config["output_dir"], "skull_stripped"),
+                datatype="anat",
+                res="native",
+                suffix="mask.nii.gz",
+                desc="synthstripbrain",
+                space=config["space"],
+                **inputs["t1w"].input_wildcards,
+            ),
+    container: config["singularity"]["synthstrip"]
+    shell:
+        "mri_synthstrip -i {input.brainskull} -o {output.brain} -m {output.mask}"
+        
+        
 rule align_template_rigid:
     input:
-        image=inputs["t1w"].input_path,
+        image=rules.skull_strip.output.brain,
     output:
         warped=bids(
             root=join(config["output_dir"], "reg_aladin"),
@@ -86,6 +110,22 @@ rule align_template_rigid:
         config["singularity"]["neuroglia"]
     shell:
         "reg_aladin -flo {input.image} -ref {params.fixed} -res {output.warped} -rigOnly -interp 0 -aff {output.xfm_ras}"
+
+rule normalize: 
+    input:
+        im=rules.align_template_rigid.output.warped,
+    output:
+        im_norm=bids(
+            root=join(config["output_dir"], "normalized"),
+            datatype="anat",
+            res="1mm",
+            suffix="T1w.nii.gz",
+            desc="synthstripnorm",
+            space=config["space"],
+            **inputs["t1w"].input_wildcards,
+        ),
+    script:
+        "./scripts/normalization_script.py"
 
 
 rule gen_grad_template:

--- a/afids-auto-train/config/snakebids.yml
+++ b/afids-auto-train/config/snakebids.yml
@@ -79,6 +79,7 @@ parse_args:
 
 singularity:
   neuroglia: docker://khanlab/neuroglia-core:latest
+  synthstrip: "intser_here"
 
 c3d:
   model_params:

--- a/afids-auto-train/config/snakebids.yml
+++ b/afids-auto-train/config/snakebids.yml
@@ -79,7 +79,7 @@ parse_args:
 
 singularity:
   neuroglia: docker://khanlab/neuroglia-core:latest
-  synthstrip: "intser_here"
+  synthstrip: "insert_here" #docker pull freesurfer/synthstrip
 
 c3d:
   model_params:

--- a/afids-auto-train/workflow/Snakefile
+++ b/afids-auto-train/workflow/Snakefile
@@ -42,9 +42,37 @@ rule all:
         #    suffix="regqc.html",
         #),
 
+rule skull_strip: 
+    input: 
+    	brainskull = inputs["t1w"].input_path,
+    output: 
+        brain=expand(
+                bids(
+                root=join(config["output_dir"], "skull_striped"),
+                datatype="anat",
+                res="native",
+                suffix="T1w.nii.gz",
+                desc="synthstrip"
+                space=config["space"],
+                **inputs["t1w"].input_wildcards,
+            ),
+        mask=expand(
+                bids(
+                root=join(config["output_dir"], "skull_striped"),
+                datatype="anat",
+                res="native",
+                suffix="brainmask.nii.gz",
+                desc="synthstrip"
+                space=config["space"],
+                **inputs["t1w"].input_wildcards,
+            ),
+    container: config["singularity"]["synthstrip"]
+    shell:
+        "mri_synthstrip -i {input.brainskull} -o {output.brain} -m {output.mask}"
+    
 rule align_template_rigid:
     input:
-        image=inputs["t1w"].input_path
+        image=rules.skull_strip.output.brain,
     output:
         warped=bids(
             root=join(config["output_dir"], "reg_aladin"),
@@ -67,10 +95,27 @@ rule align_template_rigid:
     shell:
         "reg_aladin -flo {input.image} -ref {params.fixed} -res {output.warped} -rigOnly -interp 0 -aff {output.xfm_ras}"
 
+rule normalize: 
+    input:
+        im=rules.align_template_rigid.output.warped,
+    output:
+        im_norm=bids(
+            root=join(config["output_dir"], "normalized"),
+            datatype="anat",
+            res="1mm",
+            suffix="normT1w.nii.gz",
+            space=config["space"],
+            **inputs["t1w"].input_wildcards,
+        ),
+    script:
+        "./scripts/normalization_script.py"
+
+
+
 rule gen_grad_template:
     input:
-        image=rules.align_template_rigid.output.warped,
-    output:
+        image=rules.normalize.outputs.im_norm,
+    output:Z
         gradx=expand(
                 bids(
                 root=join(config["output_dir"], "c3d_grad"),

--- a/afids-auto-train/workflow/Snakefile
+++ b/afids-auto-train/workflow/Snakefile
@@ -48,7 +48,7 @@ rule skull_strip:
     output: 
         brain=expand(
                 bids(
-                root=join(config["output_dir"], "skull_striped"),
+                root=join(config["output_dir"], "skull_stripped"),
                 datatype="anat",
                 res="native",
                 suffix="T1w.nii.gz",
@@ -58,11 +58,11 @@ rule skull_strip:
             ),
         mask=expand(
                 bids(
-                root=join(config["output_dir"], "skull_striped"),
+                root=join(config["output_dir"], "skull_stripped"),
                 datatype="anat",
                 res="native",
-                suffix="brainmask.nii.gz",
-                desc="synthstrip"
+                suffix="mask.nii.gz",
+                desc="synthstripbrain"
                 space=config["space"],
                 **inputs["t1w"].input_wildcards,
             ),
@@ -103,7 +103,8 @@ rule normalize:
             root=join(config["output_dir"], "normalized"),
             datatype="anat",
             res="1mm",
-            suffix="normT1w.nii.gz",
+            suffix="T1w.nii.gz",
+            desc="synthstripnorm"
             space=config["space"],
             **inputs["t1w"].input_wildcards,
         ),

--- a/afids-auto-train/workflow/Snakefile
+++ b/afids-auto-train/workflow/Snakefile
@@ -46,23 +46,21 @@ rule skull_strip:
     input: 
     	brainskull = inputs["t1w"].input_path,
     output: 
-        brain=expand(
-                bids(
+        brain= bids(
                 root=join(config["output_dir"], "skull_stripped"),
                 datatype="anat",
                 res="native",
                 suffix="T1w.nii.gz",
-                desc="synthstrip"
+                desc="synthstrip",
                 space=config["space"],
                 **inputs["t1w"].input_wildcards,
             ),
-        mask=expand(
-                bids(
+        mask=   bids(
                 root=join(config["output_dir"], "skull_stripped"),
                 datatype="anat",
                 res="native",
                 suffix="mask.nii.gz",
-                desc="synthstripbrain"
+                desc="synthstripbrain",
                 space=config["space"],
                 **inputs["t1w"].input_wildcards,
             ),
@@ -104,7 +102,7 @@ rule normalize:
             datatype="anat",
             res="1mm",
             suffix="T1w.nii.gz",
-            desc="synthstripnorm"
+            desc="synthstripnorm",
             space=config["space"],
             **inputs["t1w"].input_wildcards,
         ),
@@ -115,8 +113,8 @@ rule normalize:
 
 rule gen_grad_template:
     input:
-        image=rules.normalize.outputs.im_norm,
-    output:Z
+        image=rules.normalize.output.im_norm,
+    output:
         gradx=expand(
                 bids(
                 root=join(config["output_dir"], "c3d_grad"),

--- a/afids-auto-train/workflow/scripts/normalization_script.py
+++ b/afids-auto-train/workflow/scripts/normalization_script.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import numpy as np
+import nibabel as nb
+
+
+    
+input_im = snakemake.input["im"]
+output_im = snakemake.output["im_norm"]
+
+
+def read_nii_metadata(nii_path):
+    """Load in nifti data and header information"""
+    nii = nib.load(nii_path)
+    nii_affine = nii.affine
+    nii_data = nii.get_fdata()
+    #added normalization 
+    nii_data = (nii_data - nii_data.min())/ (nii_data.max() - nii_data.min())
+
+    return nii_affine, nii_data
+
+intermediate = read_nii_metadata(input_im)
+
+
+output_im = nib.Nifti1Image(intermediate[1], affine=intermediate[0])


### PR DESCRIPTION
In this PR, I add two new rules: 

1) skull stripping rule. This comes before the rigid registration (have demonstated in the past it may help with registstration especially if there is contrast enhancement). This rule will use a tool called synthstrip which has been demonstrated as a robust tool (see [here](https://www.sciencedirect.com/science/article/pii/S1053811922005900?via%3Dihub)). We have tested this internally and perfornamce is good for purposes of AFIDs prediction (attached output image). The flag "-m" allows for the generation of a brainmask which is to be used at fine tuning the thresholding stage of model application. 
<img width="719" alt="Screenshot 2022-12-13 at 5 25 01 PM" src="https://user-images.githubusercontent.com/46094728/207457936-ccf68aec-b4cb-4225-8035-d8181b224094.png">

2) MRI volume normalization rule. This rule is performed after rigid registration and before training. Althugh random forests are quite robust even in cases of varying feature scales, normalizing values between 0-1 can be helpful here due to the heterogeniety of MRI scanners and dataset we utilize for this problem. Equation implemented summarized [here](https://www.indeed.com/career-advice/career-development/normalization-formula). 